### PR TITLE
Allow passing tuples when logging variables

### DIFF
--- a/stlog/base.py
+++ b/stlog/base.py
@@ -85,12 +85,12 @@ RESERVED_ATTRS: tuple[str, ...] = (
 def check_json_types_or_raise(to_check: Any) -> None:
     if to_check is None:
         return
-    if not isinstance(to_check, (dict, list, bool, str, int, float, bool)):
+    if not isinstance(to_check, (dict, tuple, list, bool, str, int, float, bool)):
         raise StlogError(
-            "to_check should be a dict/list/bool/str/int/float/bool/None, found %s"
+            "to_check should be a dict/tuple/list/bool/str/int/float/bool/None, found %s"
             % type(to_check)
         )
-    if isinstance(to_check, list):
+    if isinstance(to_check, (list, tuple)):
         for item in to_check:
             check_json_types_or_raise(item)
     elif isinstance(to_check, dict):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -20,6 +20,7 @@ from stlog.base import (
 def test_check_json_types_or_raise():
     check_json_types_or_raise(None)
     check_json_types_or_raise("foo")
+    check_json_types_or_raise(("foo", "bar"))
     check_json_types_or_raise([{"foo": 123, "bar": 456}, None, [1, 2, 3]])
     with pytest.raises(StlogError):
         # invalid type


### PR DESCRIPTION
When adding structured logging to my project, I was sadly hit by a `StlogError` when passing a tuple to the log function, when parsing a tuple to JSON, it is automatically converted to a list, so it should follow the same constraints that a list does.

So in this PR, I'm adding checks to tuple so it is allowed, using the same route lists are using: iterating over the tuple and testing each type separately.

Thanks !