### PR TITLE
feat: add `context` attribute on logger objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,20 +134,25 @@ from stlog import LogContext, getLogger, setup
 # Set the logging default configuration (human output on stderr)
 setup()
 
+# Get a logger
+logger = getLogger(__name__)
+
 # ...
 
 # Set the (kind of) global execution context
 # (thread, worker, async friendly: one context by execution)
 # (for example in a wsgi/asgi middleware)
-# Note: ExecutionContext is a static class, so a kind of global singleton
-LogContext.reset_context()
-LogContext.add(request_id="4c2383f5")
+
+# You can do it through the logger with its `context` attribute (recommended):
+logger.context.reset_context()
+logger.context.add(request_id="4c2383f5")
+
+# ...or through the LogContext static class directly (both are equivalent,
+# logger.context *is* the LogContext static class):
 LogContext.add(client_id=456, http_method="GET")
 
 # ... in another file/class/...
 
-# Get a logger
-logger = getLogger(__name__)
 logger.info("It works", foo="bar", x=123)
 logger.critical("Houston, we have a problem!")
  
@@ -170,7 +175,7 @@ What about if you want to get a more parsing friendly output (for example in JSO
 
 ```python
 import sys
-from stlog import LogContext, getLogger, setup
+from stlog import getLogger, setup
 from stlog.output import StreamOutput
 from stlog.formatter import HumanFormatter, JsonFormatter
 
@@ -184,11 +189,12 @@ setup(
     ]
 )
 
-# See previous example for details
-LogContext.reset_context()
-LogContext.add(request_id="4c2383f5")
-LogContext.add(client_id=456, http_method="GET")
 logger = getLogger(__name__)
+
+# See previous example for details
+logger.context.reset_context()
+logger.context.add(request_id="4c2383f5")
+logger.context.add(client_id=456, http_method="GET")
 logger.info("It works", foo="bar", x=123)
 logger.critical("Houston, we have a problem!")
  
@@ -215,7 +221,7 @@ JSON ouput (on `stdout`) for machines:
     "request_id": "4c2383f5",
     "source": {
         "funcName": "<module>",
-        "lineno": 21,
+        "lineno": 22,
         "module": "qs3",
         "path": "/path/filename.py",
         "process": 6789,
@@ -235,7 +241,7 @@ JSON ouput (on `stdout`) for machines:
     "request_id": "4c2383f5",
     "source": {
         "funcName": "<module>",
-        "lineno": 22,
+        "lineno": 23,
         "module": "qs3",
         "path": "/path/filename.py",
         "process": 6789,

--- a/docs/python/qs2.py
+++ b/docs/python/qs2.py
@@ -3,19 +3,24 @@ from stlog import LogContext, getLogger, setup
 # Set the logging default configuration (human output on stderr)
 setup()
 
+# Get a logger
+logger = getLogger(__name__)
+
 # ...
 
 # Set the (kind of) global execution context
 # (thread, worker, async friendly: one context by execution)
 # (for example in a wsgi/asgi middleware)
-# Note: ExecutionContext is a static class, so a kind of global singleton
-LogContext.reset_context()
-LogContext.add(request_id="4c2383f5")
+
+# You can do it through the logger with its `context` attribute (recommended):
+logger.context.reset_context()
+logger.context.add(request_id="4c2383f5")
+
+# ...or through the LogContext static class directly (both are equivalent,
+# logger.context *is* the LogContext static class):
 LogContext.add(client_id=456, http_method="GET")
 
 # ... in another file/class/...
 
-# Get a logger
-logger = getLogger(__name__)
 logger.info("It works", foo="bar", x=123)
 logger.critical("Houston, we have a problem!")

--- a/docs/python/qs3.py
+++ b/docs/python/qs3.py
@@ -1,5 +1,5 @@
 import sys
-from stlog import LogContext, getLogger, setup
+from stlog import getLogger, setup
 from stlog.output import StreamOutput
 from stlog.formatter import HumanFormatter, JsonFormatter
 
@@ -13,10 +13,11 @@ setup(
     ]
 )
 
-# See previous example for details
-LogContext.reset_context()
-LogContext.add(request_id="4c2383f5")
-LogContext.add(client_id=456, http_method="GET")
 logger = getLogger(__name__)
+
+# See previous example for details
+logger.context.reset_context()
+logger.context.add(request_id="4c2383f5")
+logger.context.add(client_id=456, http_method="GET")
 logger.info("It works", foo="bar", x=123)
 logger.critical("Houston, we have a problem!")

--- a/docs/python/usage3.py
+++ b/docs/python/usage3.py
@@ -1,11 +1,13 @@
-from stlog import setup, getLogger, LogContext
+from stlog import setup, getLogger
 
 # in the main
 setup()
 
+logger = getLogger("myloggername")
+
 # somewhere (wsgi/asgi middlewares...)
-LogContext.reset_context()
-LogContext.add(request_id=15843224, http_method="GET", authenticated=True)
+logger.context.reset_context()
+logger.context.add(request_id=15843224, http_method="GET", authenticated=True)
 
 # elsewhere
-getLogger("myloggername").info("this is a test")
+logger.info("this is a test")

--- a/docs/python/usage3bis.py
+++ b/docs/python/usage3bis.py
@@ -1,11 +1,11 @@
-from stlog import setup, getLogger, LogContext
+from stlog import setup, getLogger
 
 # in the main
 setup()
 
 logger = getLogger("myloggername")
 
-with LogContext.bind(foo="bar", foo2="123"):
+with logger.context.bind(foo="bar", foo2="123"):
     logger.info("this is a test", foo3="baz")
 
 logger.info("this is another test", foo3="baz")

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -77,10 +77,13 @@ In both cases, env variables are only read once (at program startup).
 
 You can completly disable this feature by setting `STLOG_IGNORE_ENV_CONTEXT=1`.
 
-### (2) With `LogContext` static class
+### (2) With the `logger.context` object
 
-You can use the static class {{apilink("LogContext")}} where you want to define some key/values that will be copied
-to each logger call context. 
+Every logger returned by {{apilink("getLogger")}} exposes a `context` attribute (pointing to the
+{{apilink("LogContext")}} static class) where you can define some key/values that will be copied
+to each logger call context.
+
+This is the recommended way to manipulate the (global) execution log context: `logger.context.add(...)`.
 
 In a web context for example, a common practice is to set some key/values in a middleware.
 
@@ -102,7 +105,7 @@ As this context is global
     You can considerer that {{ apilink("LogContext") }} is just a light wrapper on {{contextvars}}.
 
 
-Note: you can also use the {{apilink("LogContext")}} class as a context manager
+Note: you can also use `logger.context` as a context manager
 
 ```python
 {{ code_example("usage3bis.py") }}

--- a/stlog/adapter.py
+++ b/stlog/adapter.py
@@ -45,7 +45,15 @@ class _KeywordArgumentAdapter(logging.LoggerAdapter):
 
 
 class StLogLoggerAdapter(_KeywordArgumentAdapter):
-    """stlog `LoggerAdapter` with `stlog.LogContext` support."""
+    """stlog `LoggerAdapter` with `stlog.LogContext` support.
+
+    Attributes:
+        context: reference to the `stlog.LogContext` static class, so you can
+            manipulate the (global) execution log context directly from the
+            logger, e.g. `logger.context.add(foo="bar")`.
+    """
+
+    context = LogContext
 
     def __init__(self, logger, extra, ignore_global_logging_context: bool = False):
         self.ignore_global_logging_context = ignore_global_logging_context

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -33,3 +33,10 @@ def test_reinject_handler(context):
 
 def test_extra_none():
     getLogger("standard").info("foo", extra=None)
+
+
+def test_logger_context(context):
+    logger = getLogger("standard")
+    assert logger.context is LogContext
+    logger.context.add(foo="bar")
+    assert logger.context.get("foo") == "bar"


### PR DESCRIPTION
## What

Add a `context` attribute on logger objects returned by `getLogger`, pointing to the `stlog.LogContext` static class. This lets you manipulate the (global) execution log context directly from a logger:

```python
logger = getLogger(__name__)
logger.context.add(request_id="4c2383f5")
```

`logger.context` *is* the `LogContext` static class, so the two ways are fully equivalent — `logger.context.add(...)` and `LogContext.add(...)` do the same thing.

## Why

Having the context reachable from the logger is more discoverable and avoids a separate import, so it's now the primary documented way of setting the context.

## Changes

- `stlog/adapter.py`: expose `LogContext` as the `context` class attribute on `StLogLoggerAdapter`.
- Docs: usage guide, quickstart examples (`qs2.py`, `qs3.py`, `usage3.py`, `usage3bis.py`) and the generated `README.md` now lead with `logger.context`. `qs2.py` shows both equivalent ways.
- Tests: add coverage for `logger.context`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)